### PR TITLE
Refactor a bit to simplify

### DIFF
--- a/bin/unzip-rename-OpenHumans-data.sh
+++ b/bin/unzip-rename-OpenHumans-data.sh
@@ -4,22 +4,15 @@
 
 # This loop will unzip the ENTRIES file; convert to json and pipe in dateString and sgv; and rename it as the projectmemberid_entries.csv
 
-#change into the folder where your OH data is downloaded to 
-cd ~/Desktop/TestExampleDataFolder
+#run this from the folder where your OH data is downloaded to 
 
 ls | while read dir; do
 
     # Print the directory/folder name you're investigating
     echo $dir
 
-    #unzip the relevant json file and re-name it with the directory name as a json 
-    gzip -cd $dir/direct-sharing-31/entries.json.gz > $dir/direct-sharing-31/${dir}_entries.json
-    
-    # print the name of the new file, to confirm it unzipped successfully
-    echo ${dir}_entries.json
-    
-    # pipe the json into csv, taking the dateString and sgv datums   
-    cat $dir/direct-sharing-31/${dir}_entries.json | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_entries.csv
+    #unzip the relevant json file and pipe the json into csv, taking just the dateString and sgv fields
+    gzip -cd $dir/direct-sharing-31/entries.json.gz | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_entries.csv
     
     #print the csv to confirm it was created
     echo ${dir}_entries.csv
@@ -28,7 +21,7 @@ ls | while read dir; do
     mkdir -p EntriesCopies
     
     # copy the csv into the top level folder
-    cp ${dir}/direct-sharing-31/${dir}_entries.csv ~/Desktop/TestExampleDataFolder/EntriesCopies/
+    cp ${dir}/direct-sharing-31/${dir}_entries.csv EntriesCopies/
     
     # print copy done, so you know that it made it through a full cycle on a single data folder
     echo "Copy done"
@@ -39,9 +32,7 @@ done
 # DO NOT UNCOMMENT UNTIL: figure out which json things we want to port (instead of dateString and sgv) into csv
 #ls | while read dir; do
 #    echo $dir 
-#        gzip -cd $dir/direct-sharing-31/profile.json.gz > $dir/direct-sharing-31/${dir}_profile.json    
-#  echo ${dir}_profile.json
-#        cat $dir/direct-sharing-31/${dir}_profile.json | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_profile.csv
+#    gzip -cd $dir/direct-sharing-31/profile.json.gz | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_profile.csv
 #    echo ${dir}_profile.csv
 #    mkdir -p ProfileCopies
 #    cp ${dir}/direct-sharing-31/${dir}_profile.csv ~/Desktop/TestExampleDataFolder/ProfileCopies/
@@ -52,9 +43,7 @@ done
 # DO NOT UNCOMMENT UNTIL: figure out which json things we want to port (instead of dateString and sgv) into csv
 #ls | while read dir; do
 #    echo $dir 
-#        gzip -cd $dir/direct-sharing-31/devicestatus.json.gz > $dir/direct-sharing-31/${dir}_devicestatus.json
-#  echo ${dir}_devicestatus.json
-#        cat $dir/direct-sharing-31/${dir}_devicestatus.json | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_devicestatus.csv
+#    gzip -cd $dir/direct-sharing-31/devicestatus.json.gz | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_devicestatus.csv
 #    echo ${dir}_devicestatus.csv
 #    mkdir -p DeviceStatusCopies
 #    cp ${dir}/direct-sharing-31/${dir}_devicestatus.csv ~/Desktop/TestExampleDataFolder/DeviceStatusCopies/
@@ -65,9 +54,7 @@ done
 # DO NOT UNCOMMENT UNTIL: figure out which json things we want to port (instead of dateString and sgv) into csv
 #ls | while read dir; do
 #    echo $dir 
-#        gzip -cd $dir/direct-sharing-31/treatments.json.gz > $dir/direct-sharing-31/${dir}_treatments.json
-#  echo ${dir}_treatments.json
-#        cat $dir/direct-sharing-31/${dir}_treatments.json | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_treatments.csv
+#    gzip -cd $dir/direct-sharing-31/treatments.json.gz | jsonv dateString,sgv > $dir/direct-sharing-31/${dir}_treatments.csv
 #    echo ${dir}_treatments.csv
 #    mkdir -p TreatmentsCopies
 #    cp ${dir}/direct-sharing-31/${dir}_treatments.csv ~/Desktop/TestExampleDataFolder/TreatmentsCopies/


### PR DESCRIPTION
This removes the intermediate write-to-json-file steps and pipes the output of `gzip -cd` directly to `jsonv`, which should also speed things up a bit and result in less disk space usage.  Also removes the hard-coded ~/Desktop/TestExampleDataFolder path to allow it to be run directly from the folder where your OH data is downloaded to, regardless of where that is.

Needs re-testing on a test OH data set: LMK if you'd like me to do that.