### PR TITLE
Create devicestatus-pull-isf-timestamp.sh

### DIFF
--- a/bin/devicestatus-pull-isf-timestamp.sh
+++ b/bin/devicestatus-pull-isf-timestamp.sh
@@ -1,0 +1,36 @@
+#The purpose of this script is to 1) pull ISF and timestamp values from devicestatus csv files 2) output to a new csv file.
+#This assumes that you have unzipped and .csv devicestatus files. If not, use the script in the OpenHumansDataTools repo prior to running this script.
+#install csvkit prior to running the script.
+
+#this script will only run with OpenAPS datasets, not Loop.
+
+#!/bin/bash
+
+#run from the folder where your OH data is downloaded to. 
+
+set -eu
+
+ls -d [0-9]* | while read dir; do
+
+	echo "Creating files for participant" $dir 
+	
+	cd $dir/direct-sharing-31/${dir}_devicestatus_csv
+	
+	mkdir -p autotune_analysis
+	
+	ls -d *.csv | while read file; do
+
+    #cut timestamp and isf values from the devicestatus files and save to a new csv file
+
+		csvcut -c openaps/enacted/timestamp $file > ${file%.csv}_timestamp.csv
+		csvcut -c openaps/enacted/reason $file | awk -F "\"*, \"*" '{print $4}' | sed 's/.*://' > ${file%.csv}_isf.csv
+		paste -d, ${file%.csv}_isf.csv <(cut -d, -f1- ${file%.csv}_timestamp.csv) > autotune_analysis/${file%.csv}_autotune.csv
+		rm ${file%.csv}_isf.csv ${file%.csv}_timestamp.csv
+
+ 		echo ${file%.csv}_autotune.csv
+	 
+	done
+	
+	cd ../../../
+  
+done

--- a/bin/devicestatus-pull-isf-timestamp.sh
+++ b/bin/devicestatus-pull-isf-timestamp.sh
@@ -12,25 +12,25 @@ set -eu
 
 ls -d [0-9]* | while read dir; do
 
-	echo "Creating files for participant" $dir 
-	
-	cd $dir/direct-sharing-31/${dir}_devicestatus_csv
-	
-	mkdir -p autotune_analysis
-	
-	ls -d *.csv | while read file; do
+    echo "Creating files for participant" $dir 
+   
+    cd $dir/direct-sharing-31/${dir}_devicestatus_*csv
+   
+    mkdir -p ISF_analysis
+    
+    ls -d *.csv | while read file; do
 
     #cut timestamp and isf values from the devicestatus files and save to a new csv file
-
-		csvcut -c openaps/enacted/timestamp $file > ${file%.csv}_timestamp.csv
-		csvcut -c openaps/enacted/reason $file | awk -F "\"*, \"*" '{print $4}' | sed 's/.*://' > ${file%.csv}_isf.csv
-		paste -d, ${file%.csv}_isf.csv <(cut -d, -f1- ${file%.csv}_timestamp.csv) > autotune_analysis/${file%.csv}_autotune.csv
-		rm ${file%.csv}_isf.csv ${file%.csv}_timestamp.csv
-
- 		echo ${file%.csv}_autotune.csv
-	 
-	done
-	
-	cd ../../../
-  
+        
+        echo "ISF,Timestamp" > ISF_analysis/${file%.csv}_isf.csv
+        csvcut -c openaps/enacted/timestamp $file > ${file%.csv}_timestamp.csv
+        csvcut -c openaps/enacted/reason $file | awk -F "\"*, \"*" '{print $4}' | sed 's/.*://' > ${file%.csv}_rawisf.csv
+        paste -d, ${file%.csv}_rawisf.csv <(cut -d, -f1- ${file%.csv}_timestamp.csv) >> ISF_analysis/${file%.csv}_isf.csv
+        rm ${file%.csv}_rawisf.csv ${file%.csv}_timestamp.csv
+        echo ${file%.csv}_isf.csv
+    
+    done
+   
+    cd ../../../
+ 
 done


### PR DESCRIPTION
[This is my first attempt at writing a bash script, so it's not the most efficient]

I used [csvkit](http://csvkit.readthedocs.io/en/1.0.2/tutorial/1_getting_started.html#installing-csvkit) to pull the ISF and timestamp variables into separate CSV files before combining them into a single file. I'd like to avoid creating the two separate CSV files and then deleting them once the combined file is created, but I was struggling with calling ISF and timestamp with just one line of code, so this is my 'good enough' solution to get started.

This script also assumes that the device status files exist in CSV format. We can add the [unzip-split-csvify-OpenHumans-data](https://github.com/danamlewis/OpenHumansDataTools/blob/master/bin/unzip-split-csvify-OpenHumans-data.sh) script above this one if that makes more sense. 