### PR TITLE
use jq instead of jsonv

### DIFF
--- a/bin/unzip-split-csvify-OpenHumans-data.sh
+++ b/bin/unzip-split-csvify-OpenHumans-data.sh
@@ -33,7 +33,7 @@ ls -d [0-9]* | while read dir; do
 
         # pipe the json into csv, taking the dateString and sgv datums
         if cat ${dir}_${file} | jq -e .[0] > /dev/null; then
-          cat ${dir}_${file} | jsonv dateString,sgv > ${dir}_${file}_csv/${dir}_${file}.csv
+          cat ${dir}_${file} | jq '.[] | [.dateString, .sgv | tostring] | join (", ")' | tr -d '"' > ${dir}_${file}.csv
         else
           echo "${dir}_${file} does not appear to be valid json"
         fi

--- a/bin/unzip-split-csvify-OpenHumans-data.sh
+++ b/bin/unzip-split-csvify-OpenHumans-data.sh
@@ -33,13 +33,13 @@ ls -d [0-9]* | while read dir; do
 
         # pipe the json into csv, taking the dateString and sgv datums
         if cat ${dir}_${file} | jq -e .[0] > /dev/null; then
-          cat ${dir}_${file} | jq '.[] | [.dateString, .sgv | tostring] | join (", ")' | tr -d '"' > ${dir}_${file}.csv
+          cat ${dir}_${file} | jq '.[] | [.dateString, .sgv | tostring] | join (", ")' | tr -d '"' > ${dir}_${file}_csv/${dir}_${file}.csv
         else
-          echo "${dir}_${file} does not appear to be valid json"
+          echo "${dir}_${file} does not appear to be valid json, or is empty"
         fi
 
         #print the csv to confirm it was created
-        ls ${dir}_${file}.csv || echo "${dir}_${file}.csv not found - continuing"
+        ls ${dir}_${file}_csv/${dir}_${file}.csv || echo "${dir}_${file}.csv not found - continuing"
 
     done
 


### PR DESCRIPTION
Apparently jsonv is also the name of a json validator installed by npm, so we can't assume it will exist or be usable.  However, jq can do what we're trying to do, so this updates unzip-split-csvify-OpenHumans-data.sh to just use that.

Also fixes the ls to look for the entries csv in the subdirectory.