### PR TITLE
Add scripts and description for AndroidAPS uploader data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,15 @@ Per the headers for the file provided as an example in this script, if needed, I
 
 ## Tool #5: Examples and descriptions of data structures from AndroidAPS uploader
 
-Project members who have used the AndroidAPS uploader will have a different series of data files available, although similar data will exist.
+Project members who have used the AndroidAPS uploader will have a different series of data files available, although similar data will exist. Depending on what stage of use someone is at (e.g. in "open loop" or early objective stage vs. an advanced user), they may not have all of the files described below.
 
 **ApplicationInfo** - contains information about the version of AndroidAPS
 
+**APSData** - contains information about algorithm predictions, calculations, and decisions. This is similar to "devicestatus" from the Nightscout uploader.
+
 **BgReadings** - contains timestamps and BG value. This is similar to "entries" from the Nightscout uploader.
+
+**CarePortalEvents** - contains information the user or system has entered as a CarePortal event.
 
 **DeviceInfo** - contains information about the mobile device used
 
@@ -84,6 +88,9 @@ Project members who have used the AndroidAPS uploader will have a different seri
 
 **Preferences** - contains information about the preferences used within AndroidAPS. [See the AndroidAPS documentation on preferences](https://androidaps.readthedocs.io/en/latest/Configuration/Preferences.html) for more details about what each of those indicate and the available setting options.
 
+**TemporaryBasals** - contains information about temporary basal rates that have been set. 
+
+**Treatments** - contains information about bolus calculations, boluses (manual or SMB), profile changes, etc. 
 
 ## Tool #6: Pull ISF from device status
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Participant ########: devicestatus CSV files created:      35
 
 ## Tool #2: Unzip and convert json to csv, on data from OH from the AndroidAPS uploader type
 
-This script checks for the existence of AndroidAPS uploader data (under direct-sharing396 folder, which is the Open Humans designation for this uploader project), unzips the files, puts the BG and timestamp in a simplified csv file (similar to "entries" from the Nightscout uploader type), and converts the remaining files into csv as well. Each .zip file remains, and a folder with the file name is created with all converted json and .csv folders below (see picture below for example). 
+[unzip-csvify-AAPS-OpenHumans-data.sh](unzip-csvify-AAPS-OpenHumans-data.sh) checks for the existence of AndroidAPS uploader data (under direct-sharing396 folder, which is the Open Humans designation for this uploader project), unzips the files, puts the BG and timestamp in a simplified csv file (similar to "entries" from the Nightscout uploader type), and converts the remaining files into csv as well. Each .zip file remains, and a folder with the file name is created with all converted json and .csv folders below (see picture below for example). 
 
 <img width="252" alt="image" src="https://user-images.githubusercontent.com/7468165/exampleAAPSconvertedtoCSV-data-example.png">
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tools to work with data downloaded from Open Humans research platform.
 
 - [Tool #1: Unzip, split if needed based on size, and convert json to csv, and do it on a full batch of downloaded data from OH.](#tool-1-unzip-split-if-needed-based-on-size-and-convert-json-to-csv-and-do-it-on-a-full-batch-of-downloaded-data-from-oh)
-- [Tool #2: Unzip, convert json to csv, on data from OH from the AndroidAPS uploader type.])(#tool-2-Unzip-and-convert-json-to-csv-on-data-from-OH-from-the-AndroidAPS-uploader-type)
+- [Tool #2: Unzip, convert json to csv, on data from OH from the AndroidAPS uploader type.](#tool-2-Unzip-and-convert-json-to-csv-on-data-from-OH-from-the-AndroidAPS-uploader-type)
 - [Tool #3: Unzip, merge, and create output file from multiple data files from an OH download](#tool-3-unzip-merge-and-create-output-file-from-multiple-data-files-from-an-oh-download)
 - [Tool #4: Examples and descriptions of the four data file types from Nightscout uploader](#tool-4-examples-and-descriptions-of-the-four-data-file-types-from-nightscout)
 - [Tool #5: Examples and descriptions of data structures from AndroidAPS uploader](#tool-5-Examples-and-descriptions-of-data-structures-from-AndroidAPS-uploader)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Project members who have used the AndroidAPS uploader will have a different seri
 
 **TemporaryBasals** - contains information about temporary basal rates that have been set. 
 
+**TempTargets** - contains information about temporary targets that have been set.
+
 **Treatments** - contains information about bolus calculations, boluses (manual or SMB), profile changes, etc. 
 
 ## Tool #6: Pull ISF from device status

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ Participant ########: devicestatus CSV files created:      35
 
 [unzip-csvify-AAPS-OpenHumans-data.sh](unzip-csvify-AAPS-OpenHumans-data.sh) checks for the existence of AndroidAPS uploader data (under direct-sharing396 folder, which is the Open Humans designation for this uploader project), unzips the files, puts the BG and timestamp in a simplified csv file (similar to "entries" from the Nightscout uploader type), and converts the remaining files into csv as well. Each .zip file remains, and a folder with the file name is created with all converted json and .csv folders below (see picture below for example). 
 
-<img width="252" alt="image" src="https://user-images.githubusercontent.com/7468165/exampleAAPSconvertedtoCSV-data-example.png">
-
 ## Tool #3: Unzip, merge, and create output file from multiple data files from an OH download
 
 [Unzip-merge-output.sh](https://github.com/danamlewis/OpenHumansDataTools/blob/master/bin/unzip-merge-output.sh)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 Tools to work with data downloaded from Open Humans research platform.
 
 - [Tool #1: Unzip, split if needed based on size, and convert json to csv, and do it on a full batch of downloaded data from OH.](#tool-1-unzip-split-if-needed-based-on-size-and-convert-json-to-csv-and-do-it-on-a-full-batch-of-downloaded-data-from-oh)
-- [Tool #2: Unzip, merge, and create output file from multiple data files from an OH download](#tool-2-unzip-merge-and-create-output-file-from-multiple-data-files-from-an-oh-download)
-- [Tool #3: Examples and descriptions of the four data file types from Nightscout](#tool-3-examples-and-descriptions-of-the-four-data-file-types-from-nightscout)
-- [Tool #4: Pull ISF from device status](#tool-4-pull-isf-from-device-status)
-- [Tool #5: Assess amount of looping data](#tool-5-assess-amount-of-looping-data)
-- [Tool #6: Outcomes](#tool-6-outcomes)
+- [Tool #2: Unzip, convert json to csv, on data from OH from the AndroidAPS uploader type.])(#tool-2-Unzip-and-convert-json-to-csv-on-data-from-OH-from-the-AndroidAPS-uploader-type)
+- [Tool #3: Unzip, merge, and create output file from multiple data files from an OH download](#tool-3-unzip-merge-and-create-output-file-from-multiple-data-files-from-an-oh-download)
+- [Tool #4: Examples and descriptions of the four data file types from Nightscout uploader](#tool-4-examples-and-descriptions-of-the-four-data-file-types-from-nightscout)
+- [Tool #5: Examples and descriptions of data structures from AndroidAPS uploader](#tool-5-Examples-and-descriptions-of-data-structures-from-AndroidAPS-uploader)
+- [Tool #6: Pull ISF from device status](#tool-6-pull-isf-from-device-status)
+- [Tool #7: Assess amount of looping data](#tool-7-assess-amount-of-looping-data)
+- [Tool #8: Outcomes](#tool-8-outcomes)
 
 ## Tool #1: Unzip, split if needed based on size, and convert json to csv, and do it on a full batch of downloaded data from OH. 
 
@@ -46,7 +48,13 @@ Creating CSV files...
 Participant ########: devicestatus CSV files created:      35
 ```
 
-## Tool #2: Unzip, merge, and create output file from multiple data files from an OH download
+## Tool #2: Unzip and convert json to csv, on data from OH from the AndroidAPS uploader type
+
+This script checks for the existence of AndroidAPS uploader data (under direct-sharing396 folder, which is the Open Humans designation for this uploader project), unzips the files, puts the BG and timestamp in a simplified csv file (similar to "entries" from the Nightscout uploader type), and converts the remaining files into csv as well. Each .zip file remains, and a folder with the file name is created with all converted json and .csv folders below (see picture below for example). 
+
+<img width="252" alt="image" src="https://user-images.githubusercontent.com/7468165/exampleAAPSconvertedtoCSV-data-example.png">
+
+## Tool #3: Unzip, merge, and create output file from multiple data files from an OH download
 
 [Unzip-merge-output.sh](https://github.com/danamlewis/OpenHumansDataTools/blob/master/bin/unzip-merge-output.sh)
 Note that this tool was designed for use with the OpenAPS and Nightscout Data Commons, which pulls in Nightscout data as json files to Open Humans. Any users will need to specify the data file types for use in the second "for" loop, but can see this script as a template for taking various pieces of data from multiple files (i.e. timezone from devicestatus and BG data from entries) and creating one file, complete with headers, ready for data analysis.
@@ -57,11 +65,27 @@ Per the headers for the file provided as an example in this script, if needed, I
 
 ![Example output file with mock data and formulas embedded for calculating these other fields](https://github.com/danamlewis/OpenHumansDataTools/blob/master/Examples/Example%20output%20file%20from%20unzip-merge-output.png)
 
-## Tool #3: Examples and descriptions of the four data file types from Nightscout
+## Tool #4: Examples and descriptions of the four data file types from Nightscout
 
 [NS-data-types.md](https://github.com/danamlewis/OpenHumansDataTools/blob/master/NS-data-types.md) attemps to explain the nuances and what is contained in each of the four data file types: profile, entries, device status, and treatments. 
 
-## Tool #4: Pull ISF from device status
+
+## Tool #5: Examples and descriptions of data structures from AndroidAPS uploader
+
+Project members who have used the AndroidAPS uploader will have a different series of data files available, although similar data will exist.
+
+**ApplicationInfo** - contains information about the version of AndroidAPS
+
+**BgReadings** - contains timestamps and BG value. This is similar to "entries" from the Nightscout uploader.
+
+**DeviceInfo** - contains information about the mobile device used
+
+**DisplayInfo** - contains information about the size of the display 
+
+**Preferences** - contains information about the preferences used within AndroidAPS. [See the AndroidAPS documentation on preferences](https://androidaps.readthedocs.io/en/latest/Configuration/Preferences.html) for more details about what each of those indicate and the available setting options.
+
+
+## Tool #6: Pull ISF from device status
 
 Requires `csvkit`, so do `sudo pip install csvkit` to install before running this script. Also, it assumes your NS data files are already in csv format, using tool #1 [Unzip-Zip-CSVify-OpenHumans-data.sh](https://github.com/danamlewis/OpenHumansDataTools/blob/master/bin/unzip-split-csvify-OpenHumans-data.sh).
 
@@ -73,7 +97,7 @@ The [devicestatus-pull-isf-timestamp.sh](https://github.com/danamlewis/OpenHuman
 Output file looks like this:
 ![Example of isf timestamp puller](https://github.com/danamlewis/OpenHumansDataTools/blob/master/Examples/Example_devicestatus_pull_ISF_timestamp.png)
 
-## Tool #5: Assess amount of looping data
+## Tool #7: Assess amount of looping data
 
 There are two methods for assessing amounts of data. 
 * You can use [howmuchBGdata.sh](https://github.com/danamlewis/OpenHumansDataTools/blob/master/bin/howmuchBGdata.sh) to see how much time worth of BG entries someone has. However, this doesn't necessarily represent time of looping data.
@@ -93,11 +117,11 @@ The original output of `howmuchdevicestatusdata.sh` is a CSV.
 
 ![Example CSV output of howmuchdevicestatusdata.sh](https://github.com/danamlewis/OpenHumansDataTools/blob/master/Examples/Example_CSVoutput_howmuchdevicestatusdata.sh.png)
 
-#### TODO for Tool 5: 
+#### TODO for Tool 7: 
 1) add Loop/enacted/timestamp to also assess Loop users
 2) add a script version to include both BG and looping data in same output CSV)
 
-## Tool #6: Outcomes
+## Tool #8: Outcomes
 
 This script ([outcomes.sh](https://github.com/danamlewis/OpenHumansDataTools/blob/master/bin/outcomes.sh)) assess the start/end of BG and looping data to calculate time spent low (default: <70 mg/dL), time in range (default: 70-180mg/dL), time spent high (default:>180mg/dL), amount of high readings, and the average glucose for the time frame where there is entries data and they are looping. 
 

--- a/bin/unzip-csvify-AAPS-OpenHumans-data.sh
+++ b/bin/unzip-csvify-AAPS-OpenHumans-data.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+  
+# The purpose of this script is to 1) unzip the .zip files; 2) convert the zipped json files into csv
+
+# This is designed for the AndroidAPS (aka AAPS) uploader data type from Open Humans, which is under direct-sharing-396. If you have other sub-folders such as direct-sharing-31, you should use the unzip-split-csvify-OpenHumans-data.sh script instead, because of the different file structures from the Nightscout Uploader.
+
+#run from the folder where your OH data is downloaded to
+
+ls -d [0-9]* | while read dir; do
+
+    # Print the directory/folder name you're investigating
+    echo $dir
+
+    # Check whether $dir/direct-sharing-396/ exists, and if so, cd into it
+    if [ -d "$dir/direct-sharing-396/" ]; then
+        cd $dir/direct-sharing-396/
+
+        # exit the script right away if something fails
+        set -e
+
+        # unzip each .zip file into a directory of the same name
+        ls *.zip | sed "s/.zip//" | while read zipfile; do
+            echo $zipfile
+            unzip -o -d $zipfile $zipfile.zip >/dev/null
+
+            cd $zipfile
+
+            # if the BgReadings.json file exists, use jq to extract the date and value keys from it
+            if [ -f "BgReadings.json" ]; then
+               jq -r '.[] | [.date, .value] | @csv' BgReadings.json > BgReadings.csv
+            fi
+
+            # use https://www.npmjs.com/package/complex-json2csv to convert all remaining files to CSV
+            # syntax is: complex-json2csv inputfile.json > outputfile.csv
+            ls *.json | while read jsonfile; do
+
+
+                # if the file is a BgReadings.json file, skip it
+                if [ $jsonfile = "BgReadings.json" ]; then
+                    echo -n ""
+                else
+                    complex-json2csv $jsonfile > ${jsonfile%.json}.csv
+                fi
+            done
+
+            cd ..
+
+        done
+
+        cd ../..
+
+    else
+        echo "No direct-sharing-396 folder found"
+        continue
+    fi
+done


### PR DESCRIPTION
This is a new script and information about the new AndroidAPS uploader, which is another method people might upload their diabetes data into Open Humans for use with projects such as the OpenAPS Data Commons or other projects.